### PR TITLE
Packages folder fix for the VS API

### DIFF
--- a/src/VisualStudioAPI/Extensibility/VsPackageInstaller.cs
+++ b/src/VisualStudioAPI/Extensibility/VsPackageInstaller.cs
@@ -384,9 +384,7 @@ namespace NuGet.VisualStudio
 
                 ResolutionContext resolution = new ResolutionContext(depBehavior, includePrerelease, false);
 
-                var dir = _solutionManager.SolutionDirectory;
-
-                NuGetPackageManager packageManager = new NuGetPackageManager(repoProvider, dir);
+                NuGetPackageManager packageManager = new NuGetPackageManager(repoProvider, _settings, _solutionManager);
 
                 // find the project
                 NuGetProject nuGetProject = PackageManagementHelpers.GetProject(_solutionManager, project, projectContext);


### PR DESCRIPTION
This fixes the packages folder path used by IVsPackageInstaller. Previously it was using the incorrect constructor for PackageManagement.

/cc @deepakaravindr 
