### PR TITLE
Fix build.cmd script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
 if "%VisualStudioVersion%"=="" call %VS2012CommandPromptBat%
-msbuild build\build.msbuild %*
+msbuild build\build.proj %*

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -151,7 +151,7 @@
         <PropertyGroup>
             <EnableCodeAnalysis Condition="'$(EnableCodeAnalysis)' == ''" >true</EnableCodeAnalysis>
         </PropertyGroup>
-        <MSBuild Projects="$(NuGetRoot)\NuGet.sln" Targets="Build" Properties="EnableCodeAnalysis=$(EnableCodeAnalysis);DeployExtension=false" />
+        <MSBuild Projects="$(NuGetRoot)\NuGet.VisualStudioExtension.sln" Targets="Build" Properties="EnableCodeAnalysis=$(EnableCodeAnalysis);DeployExtension=false" />
     </Target>
 
     <Target Name="BuildMono">


### PR DESCRIPTION
The [docs](http://docs.nuget.org/Contribute/Setting-up-the-NuGet-Development-Environment) describe a build.cmd that should get folks started. The docs are quite old, and the script is broken. This fixes the build script as far as I can figure -- it still fails because packages fail to restore, but it gets further.
