### PR TITLE
Replacing VSHPROPID_ProjectCapabilities with IsCapabilityMatch

### DIFF
--- a/src/PackageManagement.PowerShellCmdlets/Utility/ProjectExtension.cs
+++ b/src/PackageManagement.PowerShellCmdlets/Utility/ProjectExtension.cs
@@ -85,22 +85,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// </summary>
         public static bool IsSharedProject(this Project project)
         {
-            bool isShared = false;
             var hier = project.ToVsHierarchy();
 
-            // VSHPROPID_ProjectCapabilities is a space delimited list of capabilities (Dev11+)
-            object capObj;
-            if (ErrorHandler.Succeeded(hier.GetProperty(root, (int)__VSHPROPID5.VSHPROPID_ProjectCapabilities, out capObj)) && capObj != null)
-            {
-                string cap = capObj as string;
-
-                if (!String.IsNullOrEmpty(cap))
-                {
-                    isShared = cap.Split(' ').Any(s => StringComparer.OrdinalIgnoreCase.Equals("SharedAssetsProject", s));
-                }
-            }
-
-            return isShared;
+            return hier.IsCapabilityMatch("SharedAssetsProject");
         }
 
         public static IVsHierarchy ToVsHierarchy(this Project project)

--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1030,22 +1030,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         public static bool IsSharedProject(EnvDTEProject envDTEProject)
         {
-            bool isShared = false;
             var hier = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
 
-            // VSHPROPID_ProjectCapabilities is a space delimited list of capabilities (Dev11+)
-            object capObj;
-            if (ErrorHandler.Succeeded(hier.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID5.VSHPROPID_ProjectCapabilities, out capObj)) && capObj != null)
-            {
-                string cap = capObj as string;
-
-                if (!String.IsNullOrEmpty(cap))
-                {
-                    isShared = cap.Split(' ').Any(s => StringComparer.OrdinalIgnoreCase.Equals("SharedAssetsProject", s));
-                }
-            }
-
-            return isShared;
+            return hier.IsCapabilityMatch("SharedAssetsProject");
         }
 
         public static bool SupportsINuGetProjectSystem(EnvDTEProject envDTEProject)


### PR DESCRIPTION
This change replaces requests for __VSHPROPID5.VSHPROPID_ProjectCapabilities with the IsCapabilityMatch extension method from the VS shell.

It looks like the line endings changed on EnvDTEProjectUtility.cs, it uses the same method as ProjectExtensions.IsSharedProject  L#1035
