### PR TITLE
Fixes the issue where 'NullReferenceException' is thrown, when a project and solution is open, but the solution is not saved

### DIFF
--- a/src/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -160,6 +160,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return _nuGetAndEnvDTEProjectCache.GetEnvDTEProjects();
         }
 
+        /// <summary>
+        /// Checks if a solution is open and is saved as required
+        /// </summary>
         public bool IsSolutionOpen
         {
             get
@@ -465,15 +468,16 @@ namespace NuGet.PackageManagement.VisualStudio
             try
             {
                 // If already initialized, need not be on the UI thread
+                // Note that _initialized is only set to true once per VS instance
                 if (!_initialized)
                 {
-                    _initialized = true;
-
                     ThreadHelper.JoinableTaskFactory.Run(async delegate
                         {
                             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                            if (_dte.Solution.IsOpen)
+
+                            if (IsSolutionOpen)
                             {
+                                _initialized = true;
                                 OnSolutionOpened();
                             }
                         });

--- a/src/VsExtension/Resources.Designer.cs
+++ b/src/VsExtension/Resources.Designer.cs
@@ -278,5 +278,14 @@ namespace NuGetVSExtension {
                 return ResourceManager.GetString("RestoringPackages", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Solution is not saved. Please ensure you have a saved solution.
+        /// </summary>
+        internal static string SolutionIsNotSaved {
+            get {
+                return ResourceManager.GetString("SolutionIsNotSaved", resourceCulture);
+            }
+        }
     }
 }

--- a/src/VsExtension/Resources.resx
+++ b/src/VsExtension/Resources.resx
@@ -192,4 +192,7 @@ To prevent NuGet from restoring packages during build, open the Visual Studio Op
   <data name="RestoringPackages" xml:space="preserve">
     <value>Restoring NuGet packages...</value>
   </data>
+  <data name="SolutionIsNotSaved" xml:space="preserve">
+    <value>Solution is not saved. Please ensure you have a saved solution</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes the issue where 'NullReferenceException' is thrown, when a project and solution is open, but the solution is not saved. Issue is filed in TFS
