### PR TITLE
Edit New issue Opt-in NuGet support for new project types #569

### DIFF
--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -656,11 +656,22 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return false;
             }
+
             int pFound;
             uint itemId;
-            VSDOCUMENTPRIORITY[] priority = new VSDOCUMENTPRIORITY[1];
-            int hr = vsProject.IsDocumentInProject(path, out pFound, priority, out itemId);
-            return ErrorHandler.Succeeded(hr) && pFound == 1 && priority[0] >= VSDOCUMENTPRIORITY.DP_Standard;
+
+            if (IsTypicalCpsProject(envDTEProject))
+            {
+                // REVIEW: We want to revisit this after RTM - the code in this if statement sould be applied to every project type.
+                // We're checking for VSDOCUMENTPRIORITY.DP_Standard here to see if the file is included in the project.
+                // Original check (outside of if) did not have this.
+                VSDOCUMENTPRIORITY[] priority = new VSDOCUMENTPRIORITY[1];
+                int hr = vsProject.IsDocumentInProject(path, out pFound, priority, out itemId);
+                return ErrorHandler.Succeeded(hr) && pFound == 1 && priority[0] >= VSDOCUMENTPRIORITY.DP_Standard;
+            }
+
+            int hres = vsProject.IsDocumentInProject(path, out pFound, new VSDOCUMENTPRIORITY[0], out itemId);
+            return ErrorHandler.Succeeded(hres) && pFound == 1;
         }
 
         // Get the ProjectItems for a folder path

--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -640,7 +640,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 ||
                 string.Equals(envDTEProject.Kind, NuGetVSConstants.FsharpProjectTypeGuid, StringComparison.OrdinalIgnoreCase)
                 ||
-                string.Equals(envDTEProject.Kind, NuGetVSConstants.JsProjectTypeGuid, StringComparison.OrdinalIgnoreCase))
+                string.Equals(envDTEProject.Kind, NuGetVSConstants.JsProjectTypeGuid, StringComparison.OrdinalIgnoreCase)
+                ||
+                string.Equals(envDTEProject.Kind, NuGetVSConstants.CpsProjectTypeGuid, StringComparison.OrdinalIgnoreCase))
             {
                 // For Wix and Nemerle projects, IsDocumentInProject() returns not found
                 // even though the file is in the project. So we use GetProjectItem()

--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -186,7 +186,23 @@ namespace NuGet.PackageManagement.VisualStudio
                 return true;
             }
 
+            if (IsTypicalCpsProject(envDTEProject))
+            {
+                return true;
+            }
+
             return envDTEProject.Kind != null && SupportedProjectTypes.Contains(envDTEProject.Kind) && !HasUnsupportedProjectCapability(envDTEProject);
+        }
+
+        private static bool IsTypicalCpsProject(EnvDTEProject envDTEProject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            Debug.Assert(envDTEProject != null);
+
+            var hierarchy = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
+
+            return hierarchy.IsCapabilityMatch("CPS + AssemblyReferences + DeclaredSourceItems + UserSourceItems");
         }
 
         internal static bool IsSolutionFolder(EnvDTEProject envDTEProject)

--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -640,9 +640,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 ||
                 string.Equals(envDTEProject.Kind, NuGetVSConstants.FsharpProjectTypeGuid, StringComparison.OrdinalIgnoreCase)
                 ||
-                string.Equals(envDTEProject.Kind, NuGetVSConstants.JsProjectTypeGuid, StringComparison.OrdinalIgnoreCase)
-                ||
-                string.Equals(envDTEProject.Kind, NuGetVSConstants.CpsProjectTypeGuid, StringComparison.OrdinalIgnoreCase))
+                string.Equals(envDTEProject.Kind, NuGetVSConstants.JsProjectTypeGuid, StringComparison.OrdinalIgnoreCase))
             {
                 // For Wix and Nemerle projects, IsDocumentInProject() returns not found
                 // even though the file is in the project. So we use GetProjectItem()

--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -44,7 +44,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 NuGetVSConstants.VbProjectTypeGuid,
                 NuGetVSConstants.CppProjectTypeGuid,
                 NuGetVSConstants.JsProjectTypeGuid,
-                NuGetVSConstants.CpsProjectTypeGuid,
                 NuGetVSConstants.FsharpProjectTypeGuid,
                 NuGetVSConstants.NemerleProjectTypeGuid,
                 NuGetVSConstants.WixProjectTypeGuid,

--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -658,8 +658,9 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             int pFound;
             uint itemId;
-            int hr = vsProject.IsDocumentInProject(path, out pFound, new VSDOCUMENTPRIORITY[0], out itemId);
-            return ErrorHandler.Succeeded(hr) && pFound == 1;
+            VSDOCUMENTPRIORITY[] priority = new VSDOCUMENTPRIORITY[1];
+            int hr = vsProject.IsDocumentInProject(path, out pFound, priority, out itemId);
+            return ErrorHandler.Succeeded(hr) && pFound == 1 && priority[0] >= VSDOCUMENTPRIORITY.DP_Standard;
         }
 
         // Get the ProjectItems for a folder path

--- a/src/PackageManagement.VisualStudio/Utility/NuGetVSConstants.cs
+++ b/src/PackageManagement.VisualStudio/Utility/NuGetVSConstants.cs
@@ -14,7 +14,6 @@ namespace NuGet.PackageManagement.VisualStudio
         public const string VbProjectTypeGuid = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
         public const string CppProjectTypeGuid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
         public const string FsharpProjectTypeGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
-        public const string CpsProjectTypeGuid = "{13B669BE-BB05-4DDF-9536-439F39A36129}";
         public const string JsProjectTypeGuid = "{262852C6-CD72-467D-83FE-5EEB1973A190}";
         public const string WixProjectTypeGuid = "{930C7802-8A8C-48F9-8165-68863BCCD9DD}";
         public const string LightSwitchProjectTypeGuid = "{ECD6D718-D1CF-4119-97F3-97C25A0DFBF9}";

--- a/src/PackageManagement.VisualStudio/Utility/NuGetVSConstants.cs
+++ b/src/PackageManagement.VisualStudio/Utility/NuGetVSConstants.cs
@@ -15,7 +15,6 @@ namespace NuGet.PackageManagement.VisualStudio
         public const string CppProjectTypeGuid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
         public const string FsharpProjectTypeGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
         public const string JsProjectTypeGuid = "{262852C6-CD72-467D-83FE-5EEB1973A190}";
-        public const string CpsProjectTypeGuid = "{13B669BE-BB05-4DDF-9536-439F39A36129}";
         public const string WixProjectTypeGuid = "{930C7802-8A8C-48F9-8165-68863BCCD9DD}";
         public const string LightSwitchProjectTypeGuid = "{ECD6D718-D1CF-4119-97F3-97C25A0DFBF9}";
         public const string NemerleProjectTypeGuid = "{edcc3b85-0bad-11db-bc1a-00112fde8b61}";

--- a/src/PackageManagement.VisualStudio/Utility/NuGetVSConstants.cs
+++ b/src/PackageManagement.VisualStudio/Utility/NuGetVSConstants.cs
@@ -14,6 +14,7 @@ namespace NuGet.PackageManagement.VisualStudio
         public const string VbProjectTypeGuid = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
         public const string CppProjectTypeGuid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
         public const string FsharpProjectTypeGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
+        public const string CpsProjectTypeGuid = "{13B669BE-BB05-4DDF-9536-439F39A36129}";
         public const string JsProjectTypeGuid = "{262852C6-CD72-467D-83FE-5EEB1973A190}";
         public const string WixProjectTypeGuid = "{930C7802-8A8C-48F9-8165-68863BCCD9DD}";
         public const string LightSwitchProjectTypeGuid = "{ECD6D718-D1CF-4119-97F3-97C25A0DFBF9}";


### PR DESCRIPTION
CPS projects are now checked for project capabilities. NuGet is made available when a CPS project has these capabilities defined:

| Project Capability | Description |
| --- | --- |
| CPS | This is a "pure" CPS based project. Visual C++ does not declare this capability, but all other CPS projects do. |
| AssemblyReferences | Indicates that the project supports assembly references (distinct from WinRTReferences) |
| DeclaredSourceItems | Indicates that the project is a typical MSBuild project (not DNX) in that it declares source items in the project itself (rather than a project.json file that assumes all files in the directory are part of a compilation). |
| UserSourceItems | Indicates that the user is allowed to add arbitrary files to their project. |

@yishaigalatzer please review

/CC @AArnott 
