### PR TITLE
Prevent restore dialog from appearing when deployments are being pefo…

### DIFF
--- a/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -20,7 +20,6 @@ using NuGet.Logging;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol.Core.Types;
@@ -167,8 +166,7 @@ namespace NuGetVSExtension
                         // Call DNU to restore for BuildIntegratedProjectSystem projects
                         var buildEnabledProjects = projects.OfType<BuildIntegratedProjectSystem>();
 
-                        var forceRestore = Action == vsBuildAction.vsBuildActionRebuildAll
-                                            || Action == vsBuildAction.vsBuildActionDeploy;
+                        var forceRestore = Action == vsBuildAction.vsBuildActionRebuildAll;
 
                         await RestoreBuildIntegratedProjectsAsync(buildEnabledProjects.ToList(), forceRestore);
                     }, JoinableTaskCreationOptions.LongRunning);
@@ -270,7 +268,7 @@ namespace NuGetVSExtension
             {
                 // Swap caches 
                 var oldCache = _buildIntegratedCache;
-                _buildIntegratedCache 
+                _buildIntegratedCache
                     = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
 
                 if (forceRestore)


### PR DESCRIPTION
…rmed.

Addresses TFS work item 1196032.
For UAP applications, each F5 \ Ctrl-F5 is a deployment which causes us to
force restore. We will avoid it by only forcing restores for rebuilds.
