### PR TITLE
VSTemplateWizard runs a design time build at the end of IWizard.ProjectGenerating

### DIFF
--- a/src/NuGet.VisualStudio.Implementation/PreinstalledPackageConfiguration.cs
+++ b/src/NuGet.VisualStudio.Implementation/PreinstalledPackageConfiguration.cs
@@ -33,7 +33,7 @@ namespace NuGet.VisualStudio
             ForceDesignTimeBuild = forceDesignTimeBuild;
         }
 
-        public ICollection<PreinstalledPackageInfo> Packages { get; }
+        public IReadOnlyList<PreinstalledPackageInfo> Packages { get; }
         public string RepositoryPath { get; }
         public bool IsPreunzipped { get; }
         public bool ForceDesignTimeBuild { get; }

--- a/src/NuGet.VisualStudio.Implementation/PreinstalledPackageConfiguration.cs
+++ b/src/NuGet.VisualStudio.Implementation/PreinstalledPackageConfiguration.cs
@@ -20,15 +20,22 @@ namespace NuGet.VisualStudio
         /// A boolean indicating whether the packages are preunzipped within the repository
         /// path.
         /// </param>
-        public PreinstalledPackageConfiguration(string repositoryPath, IEnumerable<PreinstalledPackageInfo> packages, bool isPreunzipped)
+        /// <param name="forceDesignTimeBuild">If true, forces a design time build after installing
+        /// the packages</param>
+        public PreinstalledPackageConfiguration(string repositoryPath,
+            IEnumerable<PreinstalledPackageInfo> packages,
+            bool isPreunzipped,
+            bool forceDesignTimeBuild)
         {
             Packages = packages.ToList().AsReadOnly();
             RepositoryPath = repositoryPath;
             IsPreunzipped = isPreunzipped;
+            ForceDesignTimeBuild = forceDesignTimeBuild;
         }
 
-        public ICollection<PreinstalledPackageInfo> Packages { get; private set; }
-        public string RepositoryPath { get; private set; }
-        public bool IsPreunzipped { get; private set; }
+        public ICollection<PreinstalledPackageInfo> Packages { get; }
+        public string RepositoryPath { get; }
+        public bool IsPreunzipped { get; }
+        public bool ForceDesignTimeBuild { get; }
     }
 }

--- a/src/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -9,7 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using EnvDTE;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TemplateWizard;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement;
@@ -25,6 +27,10 @@ namespace NuGet.VisualStudio
     public class VsTemplateWizard : IVsTemplateWizard
     {
         private const string DefaultRepositoryDirectory = "packages";
+        private const string WizardDataElementName = "WizardData";
+        private const string IsPreunzippedAttributeName = "isPreunzipped";
+        private const string ForceDesignTimeBuildAttributeName = "forceDesignTimeBuild";
+
         private readonly IVsPackageInstaller _installer;
         private IEnumerable<PreinstalledPackageConfiguration> _configurations;
 
@@ -74,30 +80,38 @@ namespace NuGet.VisualStudio
             IEnumerable<IRegistryKey> registryKeys = null)
         {
             // Ignore XML namespaces since VS does not check them either when loading vstemplate files.
-            IEnumerable<XElement> packagesElements = document.Root.ElementsNoNamespace("WizardData")
+            var packagesElements = document.Root
+                .ElementsNoNamespace(WizardDataElementName)
                 .ElementsNoNamespace("packages");
 
             foreach (var packagesElement in packagesElements)
             {
                 IList<PreinstalledPackageInfo> packages = new PreinstalledPackageInfo[0];
                 string repositoryPath = null;
-                bool isPreunzipped = false;
+                var isPreunzipped = false;
+                var forceDesignTimeBuild = false;
 
-                string isPreunzippedString = packagesElement.GetOptionalAttributeValue("isPreunzipped");
-                if (!String.IsNullOrEmpty(isPreunzippedString))
+                var isPreunzippedString = packagesElement.GetOptionalAttributeValue(IsPreunzippedAttributeName);
+                if (!string.IsNullOrEmpty(isPreunzippedString))
                 {
                     Boolean.TryParse(isPreunzippedString, out isPreunzipped);
+                }
+
+                var forceDesignTimeBuildString = packagesElement.GetOptionalAttributeValue(ForceDesignTimeBuildAttributeName);
+                if (!string.IsNullOrEmpty(forceDesignTimeBuildString))
+                {
+                    Boolean.TryParse(forceDesignTimeBuildString, out forceDesignTimeBuild);
                 }
 
                 packages = GetPackages(packagesElement).ToList();
 
                 if (packages.Count > 0)
                 {
-                    RepositoryType repositoryType = GetRepositoryType(packagesElement);
+                    var repositoryType = GetRepositoryType(packagesElement);
                     repositoryPath = GetRepositoryPath(packagesElement, repositoryType, vsTemplatePath, vsExtensionManager, registryKeys);
                 }
 
-                yield return new PreinstalledPackageConfiguration(repositoryPath, packages, isPreunzipped);
+                yield return new PreinstalledPackageConfiguration(repositoryPath, packages, isPreunzipped, forceDesignTimeBuild);
             }
         }
 
@@ -230,11 +244,49 @@ namespace NuGet.VisualStudio
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+            var forceDesignTimeBuild = false;
             foreach (var configuration in _configurations)
             {
                 if (configuration.Packages.Any())
                 {
-                    await _preinstalledPackageInstaller.PerformPackageInstallAsync(_installer, project, configuration, ShowWarningMessage, ShowErrorMessage);
+                    await _preinstalledPackageInstaller.PerformPackageInstallAsync(_installer,
+                        project,
+                        configuration,
+                        ShowWarningMessage,
+                        ShowErrorMessage);
+                }
+
+                if (configuration.ForceDesignTimeBuild)
+                {
+                    forceDesignTimeBuild = true;
+                }
+            }
+
+            if (forceDesignTimeBuild)
+            {
+                RunDesignTimeBuild(project);
+            }
+        }
+
+        private void RunDesignTimeBuild(Project project)
+        {
+            var solution = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) as IVsSolution;
+
+            if (solution != null)
+            {
+                IVsHierarchy hierarchy;
+                if (ErrorHandler.Succeeded(solution.GetProjectOfUniqueName(project.UniqueName, out hierarchy))
+                    && hierarchy != null)
+                {
+                    var solutionBuild = hierarchy as IVsProjectBuildSystem;
+
+                    if (solutionBuild != null)
+                    {
+                        if (ErrorHandler.Succeeded(solutionBuild.StartBatchEdit()))
+                        {
+                            solutionBuild.EndBatchEdit();
+                        }
+                    }
                 }
             }
         }

--- a/src/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
+++ b/src/NuGet.VisualStudio.Implementation/VsTemplateWizard.cs
@@ -97,7 +97,9 @@ namespace NuGet.VisualStudio
                     Boolean.TryParse(isPreunzippedString, out isPreunzipped);
                 }
 
-                var forceDesignTimeBuildString = packagesElement.GetOptionalAttributeValue(ForceDesignTimeBuildAttributeName);
+                var forceDesignTimeBuildString =
+                    packagesElement.GetOptionalAttributeValue(ForceDesignTimeBuildAttributeName);
+
                 if (!string.IsNullOrEmpty(forceDesignTimeBuildString))
                 {
                     Boolean.TryParse(forceDesignTimeBuildString, out forceDesignTimeBuild);
@@ -108,10 +110,19 @@ namespace NuGet.VisualStudio
                 if (packages.Count > 0)
                 {
                     var repositoryType = GetRepositoryType(packagesElement);
-                    repositoryPath = GetRepositoryPath(packagesElement, repositoryType, vsTemplatePath, vsExtensionManager, registryKeys);
+                    repositoryPath = GetRepositoryPath(
+                        packagesElement,
+                        repositoryType,
+                        vsTemplatePath,
+                        vsExtensionManager,
+                        registryKeys);
                 }
 
-                yield return new PreinstalledPackageConfiguration(repositoryPath, packages, isPreunzipped, forceDesignTimeBuild);
+                yield return new PreinstalledPackageConfiguration(
+                    repositoryPath,
+                    packages,
+                    isPreunzipped,
+                    forceDesignTimeBuild);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/953

VSTemplateWizard runs a design time build at the end of IWizard.ProjectGenerating, if there is an attribute 'forceDesignTimeBuild' in 'WizardData' section of the relevant vstemplate file

@yishaigalatzer, @emgarten 
