### PR TITLE
Call DTE.ProjectItem.FileNames with 1 index

### DIFF
--- a/src/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -89,7 +89,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // find the project.json file if it exists in the project
                 // projects with no project.json file should use null for the spec path
                 var jsonConfigItem = project.ProjectItems.OfType<ProjectItem>()
-                    .FirstOrDefault(pi => StringComparer.Ordinal.Equals(pi.Name, BuildIntegratedProjectUtility.ProjectConfigFileName))?.FileNames[0];
+                    .FirstOrDefault(pi => StringComparer.Ordinal.Equals(pi.Name, BuildIntegratedProjectUtility.ProjectConfigFileName))?.FileNames[1];
 
                 var projectUniqueName = await EnvDTEProjectUtility.GetCustomUniqueNameAsync(project);
 


### PR DESCRIPTION
DTE.ProjectItem.FileNames is a 1-index array rather than a 0-index array, as MSDN documents for the API. This fixes NuGet to call it appropriately.

Fix nuget/home#1090
