### PR TITLE
Part-II of Fix to 1081. Fixes https://github.com/NuGet/Home/issues/1081

### DIFF
--- a/src/PackageManagement.PowerShellCmdlets/Cmdlets/AddBindingRedirectCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/Cmdlets/AddBindingRedirectCommand.cs
@@ -32,7 +32,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             ThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    CheckForSolutionOpen();
+                    CheckSolutionState();
 
                     var projects = new List<Project>();
 

--- a/src/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
@@ -110,7 +110,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             // If Remote & Updates set of parameters are not specified, list the installed package.
             if (!UseRemoteSource)
             {
-                CheckForSolutionOpen();
+                CheckSolutionState();
 
                 var packagesToDisplay = ThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
@@ -155,7 +155,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 // Get package udpates from the current source and taking targetframeworks into account.
                 else
                 {
-                    CheckForSolutionOpen();
+                    CheckSolutionState();
                     ThreadHelper.JoinableTaskFactory.Run(async delegate
                     {
                         await WriteUpdatePackagesFromRemoteSourceAsyncInSolution();

--- a/src/PackageManagement.PowerShellCmdlets/Cmdlets/GetProjectCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/Cmdlets/GetProjectCommand.cs
@@ -29,7 +29,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         private void Preprocess()
         {
-            CheckForSolutionOpen();
+            CheckSolutionState();
             GetNuGetProject();
         }
 

--- a/src/PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         private void Preprocess()
         {
-            CheckForSolutionOpen();
+            CheckSolutionState();
             GetNuGetProject(ProjectName);
             ThreadHelper.JoinableTaskFactory.Run(CheckMissingPackagesAsync);
         }

--- a/src/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -184,6 +184,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             try
             {
+                VsSolutionManager.ThrowIfNotAvailable();
+
                 ProcessRecordCore();
             }
             catch (Exception ex)

--- a/src/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -184,8 +184,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             try
             {
-                VsSolutionManager.ThrowIfNotAvailable();
-
                 ProcessRecordCore();
             }
             catch (Exception ex)
@@ -344,11 +342,20 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// <summary>
         /// Check if solution is open. If not, throw terminating error
         /// </summary>
-        protected void CheckForSolutionOpen()
+        protected void CheckSolutionState()
         {
             if (!VsSolutionManager.IsSolutionOpen)
             {
                 ErrorHandler.ThrowSolutionNotOpenTerminatingError();
+            }
+
+            if (!VsSolutionManager.IsSolutionAvailable)
+            {
+                ErrorHandler.HandleException(
+                    new InvalidOperationException(VisualStudio.Strings.SolutionIsNotSaved),
+                    terminating: true,
+                    errorId: NuGetErrorId.UnsavedSolution,
+                    category: ErrorCategory.InvalidOperation);
             }
         }
 

--- a/src/PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         protected virtual void Preprocess()
         {
-            CheckForSolutionOpen();
+            CheckSolutionState();
             UpdateActiveSourceRepository(Source);
             GetNuGetProject(ProjectName);
             DetermineFileConflictAction();

--- a/src/PackageManagement.PowerShellCmdlets/Utility/NuGetErrorId.cs
+++ b/src/PackageManagement.PowerShellCmdlets/Utility/NuGetErrorId.cs
@@ -13,6 +13,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         public const string NoCompatibleProjects = "NuGetNoCompatibleProjects";
         public const string ProjectNotFound = "NuGetProjectNotFound";
         public const string NoActiveSolution = "NuGetNoActiveSolution";
+        public const string UnsavedSolution = "NuGetUnsavedSolution";
         public const string FileNotFound = "NuGetFileNotFound";
         public const string FileExistsNoClobber = "NuGetFileExistsNoClobber";
         public const string TooManySpecFiles = "NuGetTooManySpecFiles";

--- a/src/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -221,7 +221,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         return false;
                     }
 
-                    if (!IsSolutionSaveAsRequired())
+                    if (!DoesSolutionRequireAnInitialSaveAs())
                     {
                         // Solution is open and 'Save As' is not required. Return true.
                         return true;
@@ -297,18 +297,10 @@ namespace NuGet.PackageManagement.VisualStudio
             return solutionFilePath;
         }
 
-        public void ThrowIfNotAvailable()
-        {
-            if (!IsSolutionAvailable)
-            {
-                throw new InvalidOperationException(Strings.SolutionIsNotAvailable);
-            }
-        }
-
         /// <summary>
         /// Checks whether the current solution is saved to disk, as opposed to be in memory.
         /// </summary>
-        private bool IsSolutionSaveAsRequired()
+        private bool DoesSolutionRequireAnInitialSaveAs()
         {
             Debug.Assert(ThreadHelper.CheckAccess());
 

--- a/src/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -187,7 +187,7 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GlobalPackagesFolder is a relative path and solution is not saved. Please save your solution or configure a globalPackagesFolder path which is a full path.
+        ///   Looks up a localized string similar to &apos;globalPackagesFolder&apos; from nuget.config file or the environment variable is &apos;{0}&apos;, a relative path and the solution is not saved. Please save your solution or configure a &apos;globalPackagesFolder&apos; which is a full path..
         /// </summary>
         public static string RelativeGlobalPackagesFolder {
             get {
@@ -196,11 +196,11 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Solution is not available. Since, there is a packages.config based project and/or globalPackagesFolder setting is a relative path, NuGet needs a saved solution to determine the solution directory. Please save your solution before managing NuGet packages..
+        ///   Looks up a localized string similar to Solution is not saved. Please save your solution before managing NuGet packages..
         /// </summary>
-        public static string SolutionIsNotAvailable {
+        public static string SolutionIsNotSaved {
             get {
-                return ResourceManager.GetString("SolutionIsNotAvailable", resourceCulture);
+                return ResourceManager.GetString("SolutionIsNotSaved", resourceCulture);
             }
         }
         

--- a/src/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -187,6 +187,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Solution is not saved. Please save your solution before managing NuGet packages..
+        /// </summary>
+        public static string SolutionIsNotSaved {
+            get {
+                return ResourceManager.GetString("SolutionIsNotSaved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uninstalling NuGet package {0}..
         /// </summary>
         public static string UninstallingPackage {

--- a/src/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -187,11 +187,20 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Solution is not saved. Please save your solution before managing NuGet packages..
+        ///   Looks up a localized string similar to GlobalPackagesFolder is a relative path and solution is not saved. Please save your solution or configure a globalPackagesFolder path which is a full path.
         /// </summary>
-        public static string SolutionIsNotSaved {
+        public static string RelativeGlobalPackagesFolder {
             get {
-                return ResourceManager.GetString("SolutionIsNotSaved", resourceCulture);
+                return ResourceManager.GetString("RelativeGlobalPackagesFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Solution is not available. Since, there is a packages.config based project and/or globalPackagesFolder setting is a relative path, NuGet needs a saved solution to determine the solution directory. Please save your solution before managing NuGet packages..
+        /// </summary>
+        public static string SolutionIsNotAvailable {
+            get {
+                return ResourceManager.GetString("SolutionIsNotAvailable", resourceCulture);
             }
         }
         

--- a/src/PackageManagement.VisualStudio/Strings.resx
+++ b/src/PackageManagement.VisualStudio/Strings.resx
@@ -183,7 +183,10 @@
   <data name="Warning_ErrorDuringProjectClosureWalk" xml:space="preserve">
     <value>Failed to resolve all project references for '{0}'. The package restore result for '{1}' may be incomplete.</value>
   </data>
-  <data name="SolutionIsNotSaved" xml:space="preserve">
-    <value>Solution is not saved. Please save your solution before managing NuGet packages.</value>
+  <data name="SolutionIsNotAvailable" xml:space="preserve">
+    <value>Solution is not available. Since, there is a packages.config based project and/or globalPackagesFolder setting is a relative path, NuGet needs a saved solution to determine the solution directory. Please save your solution before managing NuGet packages.</value>
+  </data>
+  <data name="RelativeGlobalPackagesFolder" xml:space="preserve">
+    <value>GlobalPackagesFolder is a relative path and solution is not saved. Please save your solution or configure a globalPackagesFolder path which is a full path</value>
   </data>
 </root>

--- a/src/PackageManagement.VisualStudio/Strings.resx
+++ b/src/PackageManagement.VisualStudio/Strings.resx
@@ -183,10 +183,10 @@
   <data name="Warning_ErrorDuringProjectClosureWalk" xml:space="preserve">
     <value>Failed to resolve all project references for '{0}'. The package restore result for '{1}' may be incomplete.</value>
   </data>
-  <data name="SolutionIsNotAvailable" xml:space="preserve">
-    <value>Solution is not available. Since, there is a packages.config based project and/or globalPackagesFolder setting is a relative path, NuGet needs a saved solution to determine the solution directory. Please save your solution before managing NuGet packages.</value>
-  </data>
   <data name="RelativeGlobalPackagesFolder" xml:space="preserve">
-    <value>GlobalPackagesFolder is a relative path and solution is not saved. Please save your solution or configure a globalPackagesFolder path which is a full path</value>
+    <value>'globalPackagesFolder' from nuget.config file or the environment variable is '{0}', a relative path and the solution is not saved. Please save your solution or configure a 'globalPackagesFolder' which is a full path.</value>
+  </data>
+  <data name="SolutionIsNotSaved" xml:space="preserve">
+    <value>Solution is not saved. Please save your solution before managing NuGet packages.</value>
   </data>
 </root>

--- a/src/PackageManagement.VisualStudio/Strings.resx
+++ b/src/PackageManagement.VisualStudio/Strings.resx
@@ -183,4 +183,7 @@
   <data name="Warning_ErrorDuringProjectClosureWalk" xml:space="preserve">
     <value>Failed to resolve all project references for '{0}'. The package restore result for '{1}' may be incomplete.</value>
   </data>
+  <data name="SolutionIsNotSaved" xml:space="preserve">
+    <value>Solution is not saved. Please save your solution before managing NuGet packages.</value>
+  </data>
 </root>

--- a/src/VsExtension/NuGetPackage.cs
+++ b/src/VsExtension/NuGetPackage.cs
@@ -648,7 +648,10 @@ namespace NuGetVSExtension
 
             var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
 
-            solutionManager.ThrowIfNotAvailable();
+            if (!solutionManager.IsSolutionAvailable)
+            {
+                throw new InvalidOperationException(Strings.SolutionIsNotSaved);
+            }
 
             var nugetProject = solutionManager.GetNuGetProject(EnvDTEProjectUtility.GetCustomUniqueName(project));
 
@@ -829,7 +832,11 @@ namespace NuGetVSExtension
                 (uint)_VSRDTFLAGS.RDT_DontSaveAs;
 
             var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
-            solutionManager.ThrowIfNotAvailable();
+
+            if (!solutionManager.IsSolutionAvailable)
+            {
+                throw new InvalidOperationException(Strings.SolutionIsNotSaved);
+            }
 
             var projects = solutionManager.GetNuGetProjects();
             if (!projects.Any())

--- a/src/VsExtension/NuGetPackage.cs
+++ b/src/VsExtension/NuGetPackage.cs
@@ -648,10 +648,7 @@ namespace NuGetVSExtension
 
             var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
 
-            if (!solutionManager.IsSolutionOpen)
-            {
-                throw new InvalidOperationException(Resources.SolutionIsNotSaved);
-            }
+            solutionManager.ThrowIfNotAvailable();
 
             var nugetProject = solutionManager.GetNuGetProject(EnvDTEProjectUtility.GetCustomUniqueName(project));
 
@@ -832,6 +829,8 @@ namespace NuGetVSExtension
                 (uint)_VSRDTFLAGS.RDT_DontSaveAs;
 
             var solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+            solutionManager.ThrowIfNotAvailable();
+
             var projects = solutionManager.GetNuGetProjects();
             if (!projects.Any())
             {

--- a/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -268,9 +268,12 @@ namespace NuGetVSExtension
                     var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(Settings);
                     if (!Path.IsPathRooted(globalPackagesFolder))
                     {
-                        WriteLine(
-                            VerbosityLevel.Quiet,
-                            NuGet.PackageManagement.VisualStudio.Strings.RelativeGlobalPackagesFolder);
+                        var message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            NuGet.PackageManagement.VisualStudio.Strings.RelativeGlobalPackagesFolder,
+                            globalPackagesFolder);
+
+                        WriteLine(VerbosityLevel.Quiet, message);
 
                         // Cannot restore packages since globalPackagesFolder is a relative path
                         // and the solution is not available
@@ -567,7 +570,7 @@ namespace NuGetVSExtension
                     {
                         WriteLine(
                             VerbosityLevel.Quiet,
-                            NuGet.PackageManagement.VisualStudio.Strings.SolutionIsNotAvailable);
+                            NuGet.PackageManagement.VisualStudio.Strings.SolutionIsNotSaved);
                     }
 
                     // Restore is not applicable, since, there is no project with installed packages

--- a/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -568,6 +568,12 @@ namespace NuGetVSExtension
                 {
                     if (!isSolutionAvailable)
                     {
+                        MessageHelper.ShowError(_errorListProvider,
+                            TaskErrorCategory.Error,
+                            TaskPriority.High,
+                            NuGet.PackageManagement.VisualStudio.Strings.SolutionIsNotSaved,
+                            hierarchyItem: null);
+
                         WriteLine(
                             VerbosityLevel.Quiet,
                             NuGet.PackageManagement.VisualStudio.Strings.SolutionIsNotSaved);

--- a/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -170,6 +171,7 @@ namespace NuGetVSExtension
                 }
 
                 var solutionDirectory = SolutionManager.SolutionDirectory;
+                var isSolutionAvailable = SolutionManager.IsSolutionAvailable;
 
                 ThreadHelper.JoinableTaskFactory.Run(async delegate
                     {
@@ -177,11 +179,16 @@ namespace NuGetVSExtension
                         // Note that projects that are not supported by NuGet, will not show up in this list
                         var projects = SolutionManager.GetNuGetProjects().ToList();
 
+                        // Get MSBuildOutputVerbosity from _dte
+                        _msBuildOutputVerbosity = GetMSBuildOutputVerbositySetting(_dte);
+
                         // Check if there are any projects that are not INuGetIntegratedProject, that is,
                         // projects with packages.config. If so, perform package restore on them
                         if (projects.Any(project => !(project is INuGetIntegratedProject)))
                         {
-                            await RestorePackagesOrCheckForMissingPackagesAsync(solutionDirectory);
+                            await RestorePackagesOrCheckForMissingPackagesAsync(
+                                solutionDirectory,
+                                isSolutionAvailable);
                         }
 
                         // Call DNU to restore for BuildIntegratedProjectSystem projects
@@ -192,7 +199,8 @@ namespace NuGetVSExtension
                         await RestoreBuildIntegratedProjectsAsync(
                             solutionDirectory,
                             buildEnabledProjects.ToList(),
-                            forceRestore);
+                            forceRestore,
+                            isSolutionAvailable);
 
                     }, JoinableTaskCreationOptions.LongRunning);
             }
@@ -248,12 +256,28 @@ namespace NuGetVSExtension
         private async Task RestoreBuildIntegratedProjectsAsync(
             string solutionDirectory,
             List<BuildIntegratedProjectSystem> buildEnabledProjects,
-            bool forceRestore)
+            bool forceRestore,
+            bool isSolutionAvailable)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             if (buildEnabledProjects.Any() && IsConsentGranted(Settings))
             {
+                if (!isSolutionAvailable)
+                {
+                    var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(Settings);
+                    if (!Path.IsPathRooted(globalPackagesFolder))
+                    {
+                        WriteLine(
+                            VerbosityLevel.Quiet,
+                            NuGet.PackageManagement.VisualStudio.Strings.RelativeGlobalPackagesFolder);
+
+                        // Cannot restore packages since globalPackagesFolder is a relative path
+                        // and the solution is not available
+                        return;
+                    }
+                }
+
                 var enabledSources = SourceRepositoryProvider.GetRepositories()
                     .Select(repo => repo.PackageSource.Source);
 
@@ -514,7 +538,9 @@ namespace NuGetVSExtension
             }
         }
 
-        private async Task RestorePackagesOrCheckForMissingPackagesAsync(string solutionDirectory)
+        private async Task RestorePackagesOrCheckForMissingPackagesAsync(
+            string solutionDirectory,
+            bool isSolutionAvailable)
         {
             // To be sure, switch to main thread before doing anything on this method
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -537,6 +563,13 @@ namespace NuGetVSExtension
 
                 if (!packages.Any())
                 {
+                    if (!isSolutionAvailable)
+                    {
+                        WriteLine(
+                            VerbosityLevel.Quiet,
+                            NuGet.PackageManagement.VisualStudio.Strings.SolutionIsNotAvailable);
+                    }
+
                     // Restore is not applicable, since, there is no project with installed packages
                     return;
                 }


### PR DESCRIPTION
1. Changed IsSolutionOpen to return even if the solution required a
   'Save As'. Note that this means that the SolutionDirectory would be the
   project directory until the solution gets saved. And, the solution file could
   get saved to a different location
2. But, Throwing an exception that the solution is not saved from the UI
   and from Powershell console
3. A dded event listeners for SolutionSaveAs and SolutionSave. Now,
   the project cache, NuGet settings among other things get reset after an
   unsaved solution has been saved
4. This change is applicable to all kinds of solutions, BuildIntegrated
   projects only solution, classic projects only with packages.config and the
   hybrid scenarios as well
5. Test: Verified that the value of globalPackagesFolder setting
   relative to solution directory changes after saving an unsaved solution
   such that solution file is 1 folder above the project folder
   directory

@yishaigalatzer @emgarten 
