### PR TITLE
Fix NuGet/Home#1191: Functional test failures on binding redirects

### DIFF
--- a/src/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -197,12 +197,13 @@ namespace NuGet.PackageManagement.VisualStudio
             // One exception is the 'packages.config' file, in which case we want to include
             // it into the project.
             // Other exceptions are 'web.config' and 'app.config'
+            var fileName = Path.GetFileName(path);
             if (File.Exists(Path.Combine(ProjectFullPath, path))
                 && !fileExistsInProject
-                && !path.Equals(Constants.PackageReferenceFile)
-                && !path.Equals("packages." + ProjectName + ".config")
-                && !path.Equals(EnvDTEProjectUtility.WebConfig)
-                && !path.Equals(EnvDTEProjectUtility.AppConfig))
+                && !fileName.Equals(Constants.PackageReferenceFile)
+                && !fileName.Equals("packages." + ProjectName + ".config")
+                && !fileName.Equals(EnvDTEProjectUtility.WebConfig)
+                && !fileName.Equals(EnvDTEProjectUtility.AppConfig))
             {
                 NuGetProjectContext.Log(ProjectManagement.MessageLevel.Warning, Strings.Warning_FileAlreadyExists, path);
             }
@@ -795,21 +796,36 @@ namespace NuGet.PackageManagement.VisualStudio
                         select p.Name;
                 });
         }
-
+        
         public IEnumerable<string> GetFullPaths(string fileName)
         {
             return ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                MicrosoftBuildEvaluationProject buildProject = EnvDTEProjectUtility.AsMicrosoftBuildEvaluationProject(EnvDTEProject);
-                return buildProject.Items.Where(
-                    projectItem =>
+                var paths = new List<string>();
+                var q = new Queue<EnvDTEProjectItems>();
+                q.Enqueue(EnvDTEProject.ProjectItems);
+                while (q.Count > 0)
+                {
+                    var items = q.Dequeue();
+                    foreach (EnvDTE.ProjectItem item in items)
                     {
-                        var itemFileName = Path.GetFileName(projectItem.EvaluatedInclude);
-                        return string.Equals(fileName, itemFileName, StringComparison.OrdinalIgnoreCase);
-                    })
-                    .Select(projectItem => Path.Combine(ProjectFullPath, projectItem.EvaluatedInclude));
+                        if (item.Kind == NuGetVSConstants.VsProjectItemKindPhysicalFile)
+                        {
+                            if (StringComparer.OrdinalIgnoreCase.Equals(item.Name, fileName))
+                            {
+                                paths.Add(item.FileNames[1]);
+                            }
+                        }
+                        else if (item.Kind == NuGetVSConstants.VsProjectItemKindPhysicalFolder)
+                        {
+                            q.Enqueue(item.ProjectItems);
+                        }
+                    }
+                }
+
+                return paths;
             });
         }
 

--- a/src/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
+++ b/src/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
@@ -194,7 +194,20 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 document.Save(memoryStream);
                 memoryStream.Seek(0, SeekOrigin.Begin);
-                MSBuildNuGetProjectSystem.AddFile(configFileFullPath, memoryStream);
+
+                // MSBuildNuGetProjectSystem.AddFile() can't handle full path if the app.config
+                // file does not exist in the project yet. This happens when NuGet first creates 
+                // app.config in the project directory. In this case, only the file name is passed.
+                var path = configFileFullPath;
+                var defaultConfigFile = Path.Combine(
+                    MSBuildNuGetProjectSystem.ProjectFullPath,
+                    ConfigurationFile);
+                if (configFileFullPath.Equals(defaultConfigFile, StringComparison.OrdinalIgnoreCase))
+                {
+                    path = ConfigurationFile;
+                }
+
+                MSBuildNuGetProjectSystem.AddFile(path, memoryStream);
             }
         }
 


### PR DESCRIPTION
There are two causes:
- MSBuild APIs were used to search files in projects. But some projects, such as Web Site, cannot be
  converted to msbuild project. So we have to use DTE API instead.
- MSBuildNuGetProjectSystem.AddFile() cannot handle full path when adding a newly created app.config.
  It requires relative path to the project's directory.

@deepakaravindr @emgarten @yishaigalatzer @zhili1208 
