### PR TITLE
Fix GetPackage test

### DIFF
--- a/src/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -368,7 +368,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             if (string.IsNullOrEmpty(projectName))
             {
                 Project = VsSolutionManager.DefaultNuGetProject;
-                if (VsSolutionManager.IsSolutionOpen
+                if (VsSolutionManager.IsSolutionAvailable
                     && Project == null)
                 {
                     ErrorHandler.WriteProjectNotFoundError("Default", terminating: true);
@@ -377,7 +377,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             else
             {
                 Project = VsSolutionManager.GetNuGetProject(projectName);
-                if (VsSolutionManager.IsSolutionOpen
+                if (VsSolutionManager.IsSolutionAvailable
                     && Project == null)
                 {
                     ErrorHandler.WriteProjectNotFoundError(projectName, terminating: true);

--- a/src/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -229,10 +229,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     Init();
                     var projects = _nuGetAndEnvDTEProjectCache.GetNuGetProjects().ToList();
-                    if (projects.Any(project => !(project is INuGetIntegratedProject)))
+                    if (!projects.Any() || projects.Any(project => !(project is INuGetIntegratedProject)))
                     {
                         // Solution is open, but not saved. That is, 'Save as' is required.
-                        // And, there is a packages.config based project. Return false.
+                        // And, there are no projects or there is a packages.config based project. Return false.
                         return false;
                     }
 

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -409,7 +409,7 @@ function Test-GetPackageDoesNotThrowIfSolutionIsTemporary {
     New-TextFile
     
     # Act and Assert
-    Assert-Throws { Get-Package } "The current environment doesn't have a solution open."
+    Assert-Throws { Get-Package } "Solution is not saved. Please save your solution before managing NuGet packages."
 }
 
 function Test-GetPackageUpdatesReturnAllVersionsIfFlagIsSpecified 


### PR DESCRIPTION
VSSolutionManager.IsSolutionAvailable should return false if there
is an open unsaved solution and there are no projects.

Validated that all the Get-Package tests and the BuildIntegrated tests pass

@yishaigalatzer @emgarten @feiling @MeniZalzman  @zhili1208 
