### PR TITLE
Fixing the NullRef exception Issue #1092

### DIFF
--- a/src/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -67,6 +67,13 @@ namespace NuGet.VisualStudio
 
                             foreach (var package in installedPackages)
                             {
+                                if (!package.PackageIdentity.HasVersion)
+                                {
+                                    // Currently we are not supporting floating versions 
+                                    // because of that we will skip this package
+                                    continue;
+                                }
+
                                 // find packages using the solution level packages folder
                                 string installPath;
                                 if (buildIntegratedProject != null)


### PR DESCRIPTION
Fixing the following issue:
https://github.com/NuGet/Home/issues/1092

if we will get a floating version package we will ignore it as part of the GetInstalledPackages API because currently we are not supporting that scenario in the specific API call

@yishaigalatzer @emgarten @deepakaravindr @feiling 
