### PR TITLE
Skip unresolved references when adding binding redirects

### DIFF
--- a/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
 using VSLangProj;
+using VSLangProj80;
 using VsWebSite;
 using Constants = NuGet.ProjectManagement.Constants;
 using EnvDTEProject = EnvDTE.Project;
@@ -1001,12 +1002,15 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 foreach (Reference reference in references)
                 {
+                    var reference3 = reference as Reference3;
+
                     // Get the referenced project from the reference if any
-                    if (reference.SourceProject == null
-                        &&
-                        reference.CopyLocal
-                        &&
-                        File.Exists(reference.Path))
+                    // In C++ projects if reference3.Resolved is false reference3.SourceProject will throw.
+                    if (reference3 != null 
+                        && reference3.Resolved
+                        && reference.SourceProject == null
+                        && reference.CopyLocal
+                        && File.Exists(reference.Path))
                     {
                         assemblies.Add(reference.Path);
                     }
@@ -1081,8 +1085,13 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 foreach (Reference reference in references)
                 {
+                    var reference3 = reference as Reference3;
+
                     // Get the referenced project from the reference if any
-                    if (reference.SourceProject != null)
+                    // C++ projects will throw on reference.SourceProject if reference3.Resolved is false
+                    if (reference3 != null
+                        && reference3.Resolved
+                        && reference.SourceProject != null)
                     {
                         envDTEProjects.Add(reference.SourceProject);
                     }


### PR DESCRIPTION
This fix checks if project references are resolved before accessing them. In C++ projects COM exceptions are thrown if properties are accessed on an unresolved project or assembly reference.

https://github.com/NuGet/Home/issues/1239

//cc @deepakaravindr @feiling @MeniZalzman @yishaigalatzer 
