### PR TITLE
Fix NuGet/Home#1379: VS 2015 produces incorrect binding redirects on …

### DIFF
--- a/src/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -796,7 +796,12 @@ namespace NuGet.PackageManagement.VisualStudio
                         select p.Name;
                 });
         }
-        
+
+        /// <summary>
+        /// Returns the list of full paths of all files in the project whose name is <paramref name="fileName"/>. DFS algorithm is used. Thus, the files directly under the project are returned first. Then files one-level deep are returned, and so-on.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
         public IEnumerable<string> GetFullPaths(string fileName)
         {
             return ThreadHelper.JoinableTaskFactory.Run(async delegate

--- a/src/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -798,10 +798,12 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         /// <summary>
-        /// Returns the list of full paths of all files in the project whose name is <paramref name="fileName"/>. DFS algorithm is used. Thus, the files directly under the project are returned first. Then files one-level deep are returned, and so-on.
+        /// Returns the list of full paths of all files in the project whose name is 
+        /// <paramref name="fileName"/>. BFS algorithm is used. Thus, the files directly under 
+        /// the project are returned first. Then files one-level deep are returned, and so-on.
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
+        /// <param name="fileName">The file name to search.</param>
+        /// <returns>The list of full paths.</returns>
         public IEnumerable<string> GetFullPaths(string fileName)
         {
             return ThreadHelper.JoinableTaskFactory.Run(async delegate

--- a/src/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
+++ b/src/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
@@ -109,8 +109,10 @@ namespace NuGet.PackageManagement.VisualStudio
         private string GetConfigurationFileFullPath()
         {
             var fullPaths = MSBuildNuGetProjectSystem.GetFullPaths(ConfigurationFile);
-            if (!fullPaths.IsEmpty())
+            if (fullPaths.Any())
             {
+                // if there are multiple configuration files in the project,
+                // we need to pick the one that is directly under the project if it exists.
                 return fullPaths.First();
             }
             else

--- a/src/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
+++ b/src/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
@@ -111,7 +111,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var fullPaths = MSBuildNuGetProjectSystem.GetFullPaths(ConfigurationFile);
             if (!fullPaths.IsEmpty())
             {
-                return fullPaths.Last();
+                return fullPaths.First();
             }
             else
             {

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -588,6 +588,14 @@ function Test-SimpleBindingRedirects {
     )
     # Arrange
     $a = New-WebApplication
+
+    # Add a another web.config under directory test
+    $testDirectory = Join-Path (Get-ProjectDir $a) "test"
+    $file = Join-Path $testDirectory "web.config"	
+    New-Item $testDirectory -ItemType Directory
+    "<configuration></configuration>" > $file
+    $a.ProjectItems.AddFromFile($file)
+
     $b = New-WebSite
     
     $projects = @($a, $b)
@@ -602,7 +610,10 @@ function Test-SimpleBindingRedirects {
     $projects | %{ Assert-Reference $_ A 1.0.0.0; 
                    Assert-Reference $_ B 2.0.0.0; }
 
+    # the binding redirect should be added to web.config directly under the project directory,
+    # not to file test\web.config.
     Assert-BindingRedirect $a web.config B '0.0.0.0-2.0.0.0' '2.0.0.0'
+
     Assert-BindingRedirect $b web.config B '0.0.0.0-2.0.0.0' '2.0.0.0'
 }
 


### PR DESCRIPTION
…update all on a VS 2013 MVC app.

The cause of the issue is that there are multiple web.config files in the project and nuget picked the
wrong one when it adds binding redirects.

The fix is to pick the one directly under the project.

@yishaigalatzer @MeniZalzman @deepakaravindr @emgarten @zhili1208 
