### PR TITLE
Updating on build restore to pass SourceRepositories to RestoreCommand

### DIFF
--- a/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -321,8 +321,7 @@ namespace NuGetVSExtension
                     }
                 }
 
-                var enabledSources = SourceRepositoryProvider.GetRepositories()
-                    .Select(repo => repo.PackageSource.Source);
+                var enabledSources = SourceRepositoryProvider.GetRepositories();
 
                 // No-op all project closures are up to date and all packages exist on disk.
                 if (await IsRestoreRequired(buildEnabledProjects, forceRestore))
@@ -451,7 +450,7 @@ namespace NuGetVSExtension
         private async Task BuildIntegratedProjectRestoreAsync(
             BuildIntegratedNuGetProject project,
             string solutionDirectory,
-            IEnumerable<string> enabledSources,
+            IEnumerable<SourceRepository> enabledSources,
             CancellationToken token)
         {
             // Go off the UI thread to perform I/O operations


### PR DESCRIPTION
Responding to NuGet.PackageManagement improvements to use the source existing source repositories during project.json restore.

//cc @deepakaravindr @yishaigalatzer @MeniZalzman @zhili1208 
